### PR TITLE
Add 'Manage your staff' journey

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -16,5 +16,6 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Components that aren't in Frontend
 @import "components/cookie-banner";
+@import "components/case-mix"; // used by 'Manage your staff' journey
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/app/assets/sass/components/_case-mix.scss
+++ b/app/assets/sass/components/_case-mix.scss
@@ -1,0 +1,71 @@
+/**
+ * Case mix key
+ */
+.case-mix-key {
+  margin: 0;
+
+  ul {
+    @extend .govuk-list;
+  }
+
+  li {
+    display: inline;
+    margin-right: 20px;
+  }
+
+  .case-mix-key__swatch {
+    border-radius: 2px;
+    margin-right: 10px;
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: middle;
+    margin-bottom: 0.2em;
+  }
+}
+
+/**
+ * Case mix bar
+ */
+.case-mix-bar {
+  display: grid;
+  grid-template-columns: var(--columns);
+  column-gap: 1px;
+  height: 30px;
+  margin: 0;
+
+  > dt {
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  > dd {
+    @include govuk-font(16);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/**
+ * Tier colours
+ */
+.case-mix__tier-a {
+  background: govuk-colour("dark-blue");
+  color: white;
+}
+.case-mix__tier-b {
+  background: govuk-colour("light-blue");
+}
+.case-mix__tier-c {
+  background: govuk-colour("pink");
+  color: white;
+}
+.case-mix__tier-d {
+  background: govuk-colour("light-pink");
+}
+.case-mix__tier-na {
+  background: govuk-colour("mid-grey");
+}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -43,6 +43,9 @@
         <li>
           <a href="/chat-to-us">Chat to us</a>
         </li>
+        <li>
+          <a href="/manage-your-staff">Manage your staff</a>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/manage-your-staff/index.html
+++ b/app/views/manage-your-staff/index.html
@@ -1,0 +1,28 @@
+{% extends "instructions.html" %}
+
+{% block pageTitle %}
+  Manage your staff
+{% endblock %}
+
+{% block instructions %}
+	<p>On the following page you will be shown a table that shows a list of Prison Offender Managers (POMs) and their work caseload. The caseloads consist of how many prisoners they have and what tier the prisoners are in.</p>
+	<p>We would like you to go through this table and see whether the information presented is legible in terms of colour, contrast and readability.</p>
+	
+	<ul class="govuk-list govuk-list--bullet">
+		<li>In the 'active probation officer POM' tab, look at Stephen Dicks, does tier A or B have more cases? How many in each?</li>
+		<li>For Laura does tier B or C have more cases? How many in each?</li>
+		<li>For Kian does tier C or D have more cases? How many in each?</li>
+		<li>How many cases does Alexandra have in tier D? (there should be no cases and so it doesn't appear on the bar chart)</li>
+		<li>On a screenreader can you tell how many cases there are in tier A for Stephen?</li>
+		<li>Can you refer back to the key to find out what tier A is?</li>
+		<li>On a screenreader how many cases does Alexandra have in tier D?</li>
+		<li>How many cases does Laura have that are tier 'N/A'?</li>
+		<li>In the 'active prison officer POMs' how many cases does Katy have in tier A?</li>
+		<li>How many cases does Ollie have?</li>
+	</ul>
+
+  {{ govukButton({
+    href: "/manage-your-staff/staff",
+    text: "Continue"
+  }) }}
+{% endblock %}

--- a/app/views/manage-your-staff/staff.html
+++ b/app/views/manage-your-staff/staff.html
@@ -1,0 +1,261 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Manage your staff
+{% endblock %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-xl">
+    Manage your staff
+  </h1>
+
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">Manage your staff</h2>
+
+    <ul class="govuk-tabs__list" role='tablist'>
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="#active_probation_poms">
+          Active Probation officer POMs (4)
+        </a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#active_prison_poms">
+          Active Prison officer POMs (2)
+        </a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#inactive_poms">
+          Inactive staff (0)
+        </a>
+      </li>
+    </ul>
+
+    <section class="govuk-tabs__panel" id="active_probation_poms">
+      <h2 class="govuk-heading-m">Active Probation officer POMs</h2>
+
+      <figure class="case-mix-key">
+        <figcaption class="govuk-heading-s">Case mix by tier</figcaption>
+        <ul>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-a"></span>
+            Tier A
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-b"></span>
+            Tier B
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-c"></span>
+            Tier C
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-d"></span>
+            Tier D
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-na"></span>
+            Tier N/A
+          </li>
+        </ul>
+      </figure>
+
+      <table class="govuk-table responsive">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">POM</th>
+            <th class="govuk-table__header" scope="col">Working pattern</th>
+            <th class="govuk-table__header" scope="col">Status</th>
+            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Case mix by tier</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">High complexity cases</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total cases</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Stephen Dicks</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Part time - 0.5</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell">
+              <dl class="case-mix-bar" style="--columns: 0 10fr 0 6fr 0 2fr;">
+                <dt>Tier A</dt>
+                <dd title="Tier A" class="case-mix__tier-a">10</dd>
+                <dt>Tier B</dt>
+                <dd title="Tier B" class="case-mix__tier-b">6</dd>
+                <dt>Tier C</dt>
+                <dd title="Tier C" class="case-mix__tier-c">2</dd>
+              </dl>
+            </td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">18</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Laura Jara-Duncan</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Full time</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell">
+              <dl class="case-mix-bar" style="--columns: 0 15fr 0 10fr 0 3fr 0 1fr;">
+                <dt>Tier B</dt>
+                <dd title="Tier B" class="case-mix__tier-b">15</dd>
+                <dt>Tier C</dt>
+                <dd title="Tier C" class="case-mix__tier-c">10</dd>
+                <dt>Tier D</dt>
+                <dd title="Tier D" class="case-mix__tier-d">3</dd>
+                <dt>Tier N/A</dt>
+                <dd title="Tier N/A" class="case-mix__tier-na">1</dd>
+              </dl>
+            </td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">29</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Kian Buckley</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Part time - 0.8</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell">
+              <dl class="case-mix-bar" style="--columns: 0 2fr 0 8fr 0 4fr 0 3fr;">
+                <dt>Tier A</dt>
+                <dd title="Tier A" class="case-mix__tier-a">2</dd>
+                <dt>Tier B</dt>
+                <dd title="Tier B" class="case-mix__tier-b">8</dd>
+                <dt>Tier C</dt>
+                <dd title="Tier C" class="case-mix__tier-c">4</dd>
+                <dt>Tier D</dt>
+                <dd title="Tier D" class="case-mix__tier-d">3</dd>
+              </dl>
+            </td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">17</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Alexandra Edwards</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Full time</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell">
+              <dl class="case-mix-bar" style="--columns: 0 2fr 0 2fr 0 9fr 0 17fr;">
+                <dt>Tier A</dt>
+                <dd title="Tier A" class="case-mix__tier-a">2</dd>
+                <dt>Tier B</dt>
+                <dd title="Tier B" class="case-mix__tier-b">2</dd>
+                <dt>Tier C</dt>
+                <dd title="Tier C" class="case-mix__tier-c">9</dd>
+                <dt>Tier D</dt>
+                <dd title="Tier D" class="case-mix__tier-d">17</dd>
+              </dl>
+            </td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">30</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="govuk-tabs__panel" id="active_prison_poms">
+      <h2 class="govuk-heading-m">Active Prison officer POMs</h2>
+
+      <figure class="case-mix-key">
+        <figcaption class="govuk-heading-s">Case mix by tier</figcaption>
+        <ul>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-a"></span>
+            Tier A
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-b"></span>
+            Tier B
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-c"></span>
+            Tier C
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-d"></span>
+            Tier D
+          </li>
+          <li>
+            <span class="case-mix-key__swatch case-mix__tier-na"></span>
+            Tier N/A
+          </li>
+        </ul>
+      </figure>
+
+      <table class="govuk-table responsive">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">POM</th>
+            <th class="govuk-table__header" scope="col">Working pattern</th>
+            <th class="govuk-table__header" scope="col">Status</th>
+            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">Case mix by tier</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">High complexity cases</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total cases</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Katy McCann</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Full time</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell">
+              <dl class="case-mix-bar" style="--columns: 0 5fr 0 7fr 0 11fr;">
+                <dt>Tier A</dt>
+                <dd title="Tier A" class="case-mix__tier-a">5</dd>
+                <dt>Tier B</dt>
+                <dd title="Tier B" class="case-mix__tier-b">7</dd>
+                <dt>Tier C</dt>
+                <dd title="Tier C" class="case-mix__tier-c">11</dd>
+              </dl>
+            </td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">23</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td aria-label="POM" class="govuk-table__cell">
+              <a href="#">Ollie Treend</a>
+            </td>
+            <td aria-label="Working pattern" class="govuk-table__cell">Part time - 0.2</td>
+            <td aria-label="Status" class="govuk-table__cell">Available</td>
+            <td aria-label="Case mix by tier" class="govuk-table__cell"></td>
+            <td aria-label="High complexity cases" class="govuk-table__cell govuk-table__cell--numeric">0</td>
+            <td aria-label="Total cases" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">0</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="govuk-tabs__panel" id="inactive_poms">
+      <h2 class="govuk-heading-m">Inactive staff</h2>
+
+      <table class="govuk-table responsive tablesorter">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">POM</th>
+            <th class="govuk-table__header" scope="col">POM type</th>
+            <th class="govuk-table__header" scope="col">Total cases</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        </tbody>
+      </table>
+    </section>
+  </div>
+
+  {{ mojButtonMenu({
+    items: [{
+    text: "Continue",
+    href: "/finish-journey",
+    classes: "govuk-button--primary"
+    }]
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
This is a basic example journey from the Manage POM Cases service, intended to test the accessibility of the 'Case Mix' UI components.

Case Mix is formed of two components:
- Case mix bar: a stacked bar chart used to visualise cases by their tier (category)
- Case mix key: a key to show which tier each colour represents in the bars

![A screenshot of the 'Manage your staff' journey](https://user-images.githubusercontent.com/7735945/114075147-1e441d80-989d-11eb-8b8b-b43a7b5dd4b7.png)
